### PR TITLE
docs: 예외 처리 문서를 실제 코드와 동기화

### DIFF
--- a/code-rules/server/05-exception-handling.md
+++ b/code-rules/server/05-exception-handling.md
@@ -4,7 +4,19 @@
 
 ---
 
-## 🏗️ 예외 구조
+## Single Source of Truth
+
+| 정보 유형 | Truth 위치 | 비고 |
+|-----------|-----------|------|
+| 에러 코드 목록 | `ErrorCode.java` | 컴파일러가 강제 |
+| 에러 응답 형식 | `ErrorResponse.java` | 코드가 Truth |
+| 예외 핸들러 | `GlobalExceptionHandler.java` | 코드가 Truth |
+
+> 이 문서에는 **패턴**과 **설계 결정**만 기록합니다.
+
+---
+
+## 예외 구조
 
 ```
 sw-campus-server/
@@ -16,304 +28,128 @@ sw-campus-server/
 ├── sw-campus-domain/
 │   └── {도메인}/
 │       └── exception/
-│           ├── {Domain}Exception.java     # 도메인 기본 예외
-│           └── {Domain}NotFoundException.java
+│           └── {Domain}NotFoundException.java  # 도메인별 예외
 │
 └── sw-campus-shared/
-    └── exception/
+    └── error/
         ├── ErrorCode.java                 # 에러 코드 정의
         └── BusinessException.java         # 비즈니스 예외 기본 클래스
 ```
 
 ---
 
-## 📋 에러 코드 정의
+## 설계 결정
 
-### shared 모듈 - ErrorCode
+### 왜 ErrorCode enum인가?
 
-```java
-// sw-campus-shared/.../exception/ErrorCode.java
-public enum ErrorCode {
-    // Common
-    INVALID_INPUT(400, "C001", "잘못된 입력입니다"),
-    INTERNAL_SERVER_ERROR(500, "C002", "서버 내부 오류입니다"),
+- **타입 안전성**: 문자열 에러 코드의 오타 방지
+- **중앙 관리**: 모든 에러 코드를 한 곳에서 확인/관리
+- **일관성**: HTTP 상태, 코드, 메시지를 묶어서 관리
 
-    // User
-    USER_NOT_FOUND(404, "U001", "사용자를 찾을 수 없습니다"),
-    USER_ALREADY_EXISTS(409, "U002", "이미 존재하는 사용자입니다"),
-    USER_PASSWORD_MISMATCH(400, "U003", "비밀번호가 일치하지 않습니다"),
+### 왜 BusinessException 단일 기본 클래스인가?
 
-    // Auth
-    AUTH_UNAUTHORIZED(401, "A001", "인증이 필요합니다"),
-    AUTH_FORBIDDEN(403, "A002", "접근 권한이 없습니다"),
-    AUTH_TOKEN_EXPIRED(401, "A003", "토큰이 만료되었습니다");
+- **핸들러 단순화**: `GlobalExceptionHandler`에서 단일 핸들러로 처리
+- **일관된 응답**: 모든 비즈니스 예외가 동일한 응답 구조
 
-    private final int status;
-    private final String code;
-    private final String message;
+### 왜 shared/error 모듈인가?
 
-    ErrorCode(int status, String code, String message) {
-        this.status = status;
-        this.code = code;
-        this.message = message;
-    }
+- **의존성 방향**: `domain → shared ← api` 구조 유지
+- **재사용**: 모든 모듈에서 ErrorCode, BusinessException 사용 가능
 
-    // getters
-}
-```
+### 에러 코드 접두사 규칙
 
-### 에러 코드 네이밍 규칙
+| 접두사 | 도메인 |
+|--------|--------|
+| C | Common (공통) |
+| M | Member (회원) |
+| A | Auth (인증) |
+| O | Organization (기관) |
+| T | cerTificate (수료증) |
+| R | Review (후기) |
+| B | Basket/Cart (장바구니) |
+| S | Survey (설문) |
+| F | File/Storage (파일) |
+| L | Lecture (강의) |
 
-| 접두사 | 도메인         |
-| ------ | -------------- |
-| C      | Common (공통)  |
-| U      | User (사용자)  |
-| A      | Auth (인증)    |
-| O      | Order (주문)   |
-| P      | Product (상품) |
+> 전체 에러 코드 목록: `ErrorCode.java` 참조
 
 ---
 
-## 🚨 예외 클래스 정의
+## 패턴
 
-### shared 모듈 - BusinessException (기본 클래스)
+### 도메인 예외 정의
 
 ```java
-// sw-campus-shared/.../exception/BusinessException.java
-public class BusinessException extends RuntimeException {
+// BusinessException을 상속하고 ErrorCode를 전달
+public class MemberNotFoundException extends BusinessException {
 
-    private final ErrorCode errorCode;
-
-    public BusinessException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
+    public MemberNotFoundException() {
+        super(ErrorCode.MEMBER_NOT_FOUND);
     }
 
-    public BusinessException(ErrorCode errorCode, String message) {
-        super(message);
-        this.errorCode = errorCode;
-    }
-
-    public ErrorCode getErrorCode() {
-        return errorCode;
+    // 상세 메시지가 필요한 경우
+    public MemberNotFoundException(Long id) {
+        super(ErrorCode.MEMBER_NOT_FOUND,
+              String.format("회원을 찾을 수 없습니다. ID: %d", id));
     }
 }
 ```
 
-### domain 모듈 - 도메인별 예외
+### Service에서 예외 사용
 
 ```java
-// sw-campus-domain/.../user/exception/UserNotFoundException.java
-public class UserNotFoundException extends BusinessException {
-
-    public UserNotFoundException() {
-        super(ErrorCode.USER_NOT_FOUND);
-    }
-
-    public UserNotFoundException(Long userId) {
-        super(ErrorCode.USER_NOT_FOUND,
-              String.format("사용자를 찾을 수 없습니다. ID: %d", userId));
-    }
-}
-
-// sw-campus-domain/.../user/exception/UserAlreadyExistsException.java
-public class UserAlreadyExistsException extends BusinessException {
-
-    public UserAlreadyExistsException(String email) {
-        super(ErrorCode.USER_ALREADY_EXISTS,
-              String.format("이미 존재하는 이메일입니다: %s", email));
-    }
+public Member getMember(Long id) {
+    return memberRepository.findById(id)
+            .orElseThrow(() -> new MemberNotFoundException(id));
 }
 ```
 
 ---
 
-## 🎯 전역 예외 핸들러
-
-### api 모듈 - GlobalExceptionHandler
-
-```java
-// sw-campus-api/.../exception/GlobalExceptionHandler.java
-@RestControllerAdvice
-@Slf4j
-public class GlobalExceptionHandler {
-
-    // 비즈니스 예외 처리
-    @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<ErrorResponse> handleBusinessException(
-            BusinessException e) {
-        log.warn("Business exception: {}", e.getMessage());
-
-        ErrorCode errorCode = e.getErrorCode();
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ErrorResponse.of(errorCode, e.getMessage()));
-    }
-
-    // 유효성 검증 예외 처리
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleValidationException(
-            MethodArgumentNotValidException e) {
-        log.warn("Validation exception: {}", e.getMessage());
-
-        String message = e.getBindingResult().getFieldErrors().stream()
-                .map(error -> error.getField() + ": " + error.getDefaultMessage())
-                .collect(Collectors.joining(", "));
-
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message));
-    }
-
-    // 기타 예외 처리 (예상치 못한 에러)
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception e) {
-        log.error("Unexpected exception: ", e);
-
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
-    }
-}
-```
-
-### api 모듈 - ErrorResponse
-
-```java
-// sw-campus-api/.../exception/ErrorResponse.java
-public record ErrorResponse(
-    String code,
-    String message,
-    LocalDateTime timestamp
-) {
-    public static ErrorResponse of(ErrorCode errorCode) {
-        return new ErrorResponse(
-            errorCode.getCode(),
-            errorCode.getMessage(),
-            LocalDateTime.now()
-        );
-    }
-
-    public static ErrorResponse of(ErrorCode errorCode, String message) {
-        return new ErrorResponse(
-            errorCode.getCode(),
-            message,
-            LocalDateTime.now()
-        );
-    }
-}
-```
-
----
-
-## 📝 예외 사용 예시
-
-### Service에서 예외 던지기
-
-```java
-// sw-campus-domain/.../user/UserService.java
-@Service
-@RequiredArgsConstructor
-public class UserService {
-
-    private final UserRepository userRepository;
-
-    public User getUser(Long id) {
-        return userRepository.findById(id)
-                .orElseThrow(() -> new UserNotFoundException(id));
-    }
-
-    public User createUser(CreateUserCommand command) {
-        // 중복 체크
-        if (userRepository.existsByEmail(command.email())) {
-            throw new UserAlreadyExistsException(command.email());
-        }
-
-        User user = User.create(command.email(), command.password(), command.nickname());
-        return userRepository.save(user);
-    }
-}
-```
-
-### API 응답 예시
-
-```json
-// 404 Not Found
-{
-  "code": "U001",
-  "message": "사용자를 찾을 수 없습니다. ID: 999",
-  "timestamp": "2025-12-01T10:30:00"
-}
-
-// 409 Conflict
-{
-  "code": "U002",
-  "message": "이미 존재하는 이메일입니다: user@example.com",
-  "timestamp": "2025-12-01T10:30:00"
-}
-
-// 400 Bad Request (유효성 검증)
-{
-  "code": "C001",
-  "message": "email: 올바른 이메일 형식이 아닙니다, password: 비밀번호는 8~20자입니다",
-  "timestamp": "2025-12-01T10:30:00"
-}
-```
-
----
-
-## 🚫 금지 사항
+## 금지 사항
 
 ### 1. 무분별한 try-catch 금지
 
 ```java
-// ❌ 나쁜 예
-public User getUser(Long id) {
-    try {
-        return userRepository.findById(id).orElseThrow();
-    } catch (Exception e) {
-        return null;  // 예외를 삼킴
-    }
+// ❌ 예외를 삼키지 말 것
+try {
+    return memberRepository.findById(id).orElseThrow();
+} catch (Exception e) {
+    return null;
 }
 
-// ✅ 좋은 예
-public User getUser(Long id) {
-    return userRepository.findById(id)
-            .orElseThrow(() -> new UserNotFoundException(id));
-}
+// ✅ 명시적 예외 던지기
+return memberRepository.findById(id)
+        .orElseThrow(() -> new MemberNotFoundException(id));
 ```
 
 ### 2. 일반 Exception 던지기 금지
 
 ```java
-// ❌ 나쁜 예
-throw new RuntimeException("사용자를 찾을 수 없습니다");
-throw new Exception("에러 발생");
+// ❌ 구체적이지 않은 예외
+throw new RuntimeException("회원을 찾을 수 없습니다");
 
-// ✅ 좋은 예
-throw new UserNotFoundException(userId);
-throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+// ✅ 도메인 예외 사용
+throw new MemberNotFoundException(memberId);
 ```
 
 ### 3. 에러 메시지에 민감 정보 포함 금지
 
 ```java
-// ❌ 나쁜 예 - 비밀번호 노출
-throw new BusinessException(ErrorCode.AUTH_FAILED,
+// ❌ 비밀번호 노출
+throw new BusinessException(ErrorCode.INVALID_CREDENTIALS,
     "비밀번호가 틀렸습니다: " + inputPassword);
 
-// ✅ 좋은 예
-throw new BusinessException(ErrorCode.AUTH_FAILED,
+// ✅ 일반적인 메시지
+throw new BusinessException(ErrorCode.INVALID_CREDENTIALS,
     "이메일 또는 비밀번호가 올바르지 않습니다");
 ```
 
 ---
 
-## ✅ 체크리스트
+## 체크리스트
 
-- [ ] 도메인별 예외 클래스가 BusinessException을 상속하는가?
-- [ ] ErrorCode에 에러 코드가 정의되어 있는가?
-- [ ] GlobalExceptionHandler에서 예외를 처리하는가?
+- [ ] 도메인별 예외 클래스가 `BusinessException`을 상속하는가?
+- [ ] `ErrorCode`에 에러 코드가 정의되어 있는가?
 - [ ] 일반 Exception 대신 구체적인 예외를 던지는가?
 - [ ] 에러 메시지에 민감 정보가 없는가?
-- [ ] 예외 발생 시 적절한 로그를 남기는가?


### PR DESCRIPTION
## 변경 사항

sw-campus-server#358 리팩토링에 맞춰 예외 처리 문서를 **Single Source of Truth** 원칙에 맞게 재작성합니다.

### 변경 전 (325줄)
- ErrorCode 전체 목록 나열
- ErrorResponse, GlobalExceptionHandler 코드 예시
- API 응답 JSON 예시
- 코드와 중복되어 불일치 발생 가능

### 변경 후 (156줄, -52%)
- **설계 결정** 중심으로 재구성
  - 왜 ErrorCode enum인가?
  - 왜 BusinessException 단일 기본 클래스인가?
  - 왜 shared/error 모듈인가?
- **패턴**만 보여주고 상세 목록은 코드 참조
- **금지 사항**과 **체크리스트** 유지

### Single Source of Truth
| 정보 유형 | Truth 위치 |
|-----------|-----------|
| 에러 코드 목록 | `ErrorCode.java` |
| 에러 응답 형식 | `ErrorResponse.java` |
| 예외 핸들러 | `GlobalExceptionHandler.java` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)